### PR TITLE
Support AWS Profile

### DIFF
--- a/Assets/Scripts/UnityModule/Command/AWS.cs
+++ b/Assets/Scripts/UnityModule/Command/AWS.cs
@@ -9,13 +9,27 @@ namespace UnityModule.Command
     {
         private enum CommandType
         {
-            S3,
+            S3
         }
 
-        private static readonly Dictionary<CommandType, string> COMMAND_MAP = new Dictionary<CommandType, string>()
+        private static readonly Dictionary<CommandType, string> COMMAND_MAP = new Dictionary<CommandType, string>
         {
-            {CommandType.S3, "s3"},
+            {CommandType.S3, "s3"}
         };
+
+        private static class Runner
+        {
+            public static string Run(CommandType commandType, IReadOnlyCollection<string> argumentMap = null)
+            {
+                var handedArgumentMap = argumentMap == null ? new List<string>() : new List<string>(argumentMap);
+                handedArgumentMap.Add($"--profile {AWSSetting.GetOrDefault().AWSProfile}");
+
+                return Runner<string>.Run(
+                    AWSSetting.GetOrDefault().PathToCommand,
+                    COMMAND_MAP[commandType],
+                    handedArgumentMap);
+            }
+        }
 
         public static class S3
         {
@@ -23,51 +37,49 @@ namespace UnityModule.Command
             {
                 Private,
                 PublicRead,
-                PublicReadWrite,
+                PublicReadWrite
             }
 
             private enum SubCommandType
             {
                 Copy,
-                List,
+                List
             }
 
             private static readonly Dictionary<SubCommandType, string> SUB_COMMAND_MAP =
-                new Dictionary<SubCommandType, string>()
+                new Dictionary<SubCommandType, string>
                 {
                     {SubCommandType.Copy, "cp"},
-                    {SubCommandType.List, "ls"},
+                    {SubCommandType.List, "ls"}
                 };
 
             private static readonly Dictionary<AccessControlListType, string> ACL_MAP =
-                new Dictionary<AccessControlListType, string>()
+                new Dictionary<AccessControlListType, string>
                 {
                     {AccessControlListType.Private, "private"},
                     {AccessControlListType.PublicRead, "public-read"},
-                    {AccessControlListType.PublicReadWrite, "public-read-write"},
+                    {AccessControlListType.PublicReadWrite, "public-read-write"}
                 };
 
             public static string Copy(string path1, string path2,
                 AccessControlListType accessControlListType = AccessControlListType.Private)
             {
-                return Runner<string>.Run(
-                    AWSSetting.GetOrDefault().PathToCommand,
-                    COMMAND_MAP[CommandType.S3],
-                    new List<string>()
+                return Runner.Run(
+                    CommandType.S3,
+                    new List<string>
                     {
                         SUB_COMMAND_MAP[SubCommandType.Copy],
                         path1,
                         path2,
-                        string.Format("--acl {0}", ACL_MAP[accessControlListType])
+                        $"--acl {ACL_MAP[accessControlListType]}"
                     }
                 );
             }
 
             public static string List(string path)
             {
-                return Runner<string>.Run(
-                    AWSSetting.GetOrDefault().PathToCommand,
-                    COMMAND_MAP[CommandType.S3],
+                return Runner.Run(
+                    CommandType.S3,
                     new List<string>
                     {
                         SUB_COMMAND_MAP[SubCommandType.List],

--- a/Assets/Scripts/UnityModule/Command/AWS.cs
+++ b/Assets/Scripts/UnityModule/Command/AWS.cs
@@ -1,49 +1,60 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityModule.Settings;
+
 // ReSharper disable UseStringInterpolation
 
-namespace UnityModule.Command {
-
-    public static class AWS {
-
-        private enum CommandType {
+namespace UnityModule.Command
+{
+    public static class AWS
+    {
+        private enum CommandType
+        {
             S3,
         }
 
-        private static readonly Dictionary<CommandType, string> COMMAND_MAP = new Dictionary<CommandType, string>() {
-            { CommandType.S3, "s3" },
+        private static readonly Dictionary<CommandType, string> COMMAND_MAP = new Dictionary<CommandType, string>()
+        {
+            {CommandType.S3, "s3"},
         };
 
-        public static class S3 {
-
-            public enum AccessControlListType {
+        public static class S3
+        {
+            public enum AccessControlListType
+            {
                 Private,
                 PublicRead,
                 PublicReadWrite,
             }
 
-            private enum SubCommandType {
+            private enum SubCommandType
+            {
                 Copy,
                 List,
             }
 
-            private static readonly Dictionary<SubCommandType, string> SUB_COMMAND_MAP = new Dictionary<SubCommandType, string>() {
-                { SubCommandType.Copy, "cp" },
-                { SubCommandType.List, "ls" },
-            };
+            private static readonly Dictionary<SubCommandType, string> SUB_COMMAND_MAP =
+                new Dictionary<SubCommandType, string>()
+                {
+                    {SubCommandType.Copy, "cp"},
+                    {SubCommandType.List, "ls"},
+                };
 
-            private static readonly Dictionary<AccessControlListType, string> ACL_MAP = new Dictionary<AccessControlListType, string>() {
-                { AccessControlListType.Private        , "private" },
-                { AccessControlListType.PublicRead     , "public-read" },
-                { AccessControlListType.PublicReadWrite, "public-read-write" },
-            };
+            private static readonly Dictionary<AccessControlListType, string> ACL_MAP =
+                new Dictionary<AccessControlListType, string>()
+                {
+                    {AccessControlListType.Private, "private"},
+                    {AccessControlListType.PublicRead, "public-read"},
+                    {AccessControlListType.PublicReadWrite, "public-read-write"},
+                };
 
-            public static string Copy(string path1, string path2, AccessControlListType accessControlListType = AccessControlListType.Private) {
+            public static string Copy(string path1, string path2,
+                AccessControlListType accessControlListType = AccessControlListType.Private)
+            {
                 return Runner<string>.Run(
                     AWSSetting.GetOrDefault().PathToCommand,
                     COMMAND_MAP[CommandType.S3],
-                    new List<string>() {
+                    new List<string>()
+                    {
                         SUB_COMMAND_MAP[SubCommandType.Copy],
                         path1,
                         path2,
@@ -64,10 +75,6 @@ namespace UnityModule.Command {
                     }
                 );
             }
-
         }
-
     }
-
-
 }

--- a/Assets/Scripts/UnityModule/Settings/AWSSetting.cs
+++ b/Assets/Scripts/UnityModule/Settings/AWSSetting.cs
@@ -29,6 +29,31 @@ namespace UnityModule.Settings
         /// </summary>
         public string PathToCommand => pathToCommand;
 
+        /// <summary>
+        /// デフォルトの aws プロフィール名
+        /// </summary>
+        private const string DefaultAWSProfile = "default";
+
+        /// <summary>
+        /// aws プロフィール名を設定している環境変数のキー
+        /// c.f. https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/cli-multiple-profiles.html
+        /// </summary>
+        private const string EnvironmentKeyAWSProfile = "AWS_PROFILE";
+
+        /// <summary>
+        /// aws プロフィール名の実態
+        /// </summary>
+        [SerializeField] private string awsProfile = (
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentKeyAWSProfile))
+                ? Environment.GetEnvironmentVariable(EnvironmentKeyAWSProfile)
+                : DefaultAWSProfile
+        );
+
+        /// <summary>
+        /// aws プロフィール名
+        /// </summary>
+        public string AWSProfile => awsProfile;
+
 #if UNITY_EDITOR
         [UnityEditor.MenuItem("Assets/Create/Settings/AWS Setting")]
         public static void CreateSettingAsset()

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,4 +1,39 @@
 {
-	"dependencies": {
-	}
+  "dependencies": {
+    "com.unity.ads": "2.0.8",
+    "com.unity.analytics": "2.0.16",
+    "com.unity.package-manager-ui": "1.9.11",
+    "com.unity.purchasing": "2.0.3",
+    "com.unity.textmeshpro": "1.2.4",
+    "com.unity.modules.ai": "1.0.0",
+    "com.unity.modules.animation": "1.0.0",
+    "com.unity.modules.assetbundle": "1.0.0",
+    "com.unity.modules.audio": "1.0.0",
+    "com.unity.modules.cloth": "1.0.0",
+    "com.unity.modules.director": "1.0.0",
+    "com.unity.modules.imageconversion": "1.0.0",
+    "com.unity.modules.imgui": "1.0.0",
+    "com.unity.modules.jsonserialize": "1.0.0",
+    "com.unity.modules.particlesystem": "1.0.0",
+    "com.unity.modules.physics": "1.0.0",
+    "com.unity.modules.physics2d": "1.0.0",
+    "com.unity.modules.screencapture": "1.0.0",
+    "com.unity.modules.terrain": "1.0.0",
+    "com.unity.modules.terrainphysics": "1.0.0",
+    "com.unity.modules.tilemap": "1.0.0",
+    "com.unity.modules.ui": "1.0.0",
+    "com.unity.modules.uielements": "1.0.0",
+    "com.unity.modules.umbra": "1.0.0",
+    "com.unity.modules.unityanalytics": "1.0.0",
+    "com.unity.modules.unitywebrequest": "1.0.0",
+    "com.unity.modules.unitywebrequestassetbundle": "1.0.0",
+    "com.unity.modules.unitywebrequestaudio": "1.0.0",
+    "com.unity.modules.unitywebrequesttexture": "1.0.0",
+    "com.unity.modules.unitywebrequestwww": "1.0.0",
+    "com.unity.modules.vehicles": "1.0.0",
+    "com.unity.modules.video": "1.0.0",
+    "com.unity.modules.vr": "1.0.0",
+    "com.unity.modules.wind": "1.0.0",
+    "com.unity.modules.xr": "1.0.0"
+  }
 }


### PR DESCRIPTION
aws cli で設定できる `--profile` オプションをサポートしてみました。
何も指定しないと `default` のようなので、`default` を明示的に指定していくスタイルにとりあえずはなっています。

[ドキュメント](https://docs.aws.amazon.com/ja_jp/cli/latest/userguide/cli-multiple-profiles.html) によると環境変数で設定することもでき、その場合の環境変数は `AWS_PROFILE` ということなので、そちらを使用してみることにしています。

テストはしていないので（ぉぃ、実際に使ってみてテストすることにしてみます・・・。

あと `AWS.cs` に関しては勝手に KidsStar 最新 C# フォーマットでリフォーマットしちゃいました。